### PR TITLE
handle differences in diagnostic tables

### DIFF
--- a/src/qccodar/app.py
+++ b/src/qccodar/app.py
@@ -66,6 +66,7 @@ def manual(datadir, pattern, configfile):
     
     # do qc for each file in the datadir --> output to RadialShorts_qcd
     for fullfn in fns:
+        print('###################')
         print('... input: %s' % fullfn)
         fn = os.path.basename(fullfn)
         ofn = do_qc(datadir, fn, pattern, qccodar_values)
@@ -79,6 +80,7 @@ def manual(datadir, pattern, configfile):
 
     # run LLUVMerger for each
     for fullfn in fns:
+        print('###################')
         print('... input: %s' % fullfn)
         fn = os.path.basename(fullfn)
         ofn = do_merge(datadir, fn, pattern, qccodar_values)

--- a/src/qccodar/codarutils.py
+++ b/src/qccodar/codarutils.py
@@ -419,11 +419,12 @@ def add_diagnostic_tables(r, shortpath):
     if hasattr(rs,'diagnostics_radial'):
         rdtdata = rs.diagnostics_radial
     else:
-        rdtdata = ''
+        # use empty dataframe
+        rdtdata = pd.DataFrame()
     if hasattr(rs,'diagnostics_hardware'):
         hdtdata = rs.diagnostics_hardware
     else:
-    	hdtdata = ''
+    	hdtdata = pd.DataFrame()
 
     for shortfile in filelist:
         shortfullfile = os.path.join(shortpath, shortfile)
@@ -440,9 +441,9 @@ def add_diagnostic_tables(r, shortpath):
                 hdtdata = pd.concat([hdtdata, hdt], ignore_index=True)
 
     # remove duplicates
-    if rdtdata != '':
+    if not rdtdata.empty:
         rdtdata = rdtdata.drop_duplicates(subset=['TYRS', 'TMON', 'TDAY', 'THRS', 'TMIN', 'TSEC'])
-    if hdtdata != '':
+    if not hdtdata.empty:
         hdtdata = hdtdata.drop_duplicates(subset=['TYRS', 'TMON', 'TDAY', 'THRS', 'TMIN', 'TSEC'])
 
     # adjust rdt for seconds from start

--- a/src/qccodar/codarutils.py
+++ b/src/qccodar/codarutils.py
@@ -83,12 +83,25 @@ def generate_radialshort(r, table_type='LLUV RDL7', numdegrees=3, weight_paramet
     rs.metadata = r.metadata
     #  '% PatternMethod: 1 PatternVectors' should be added but I'm not sure how to
     #   insert at a specific position in Ordered dictionary
-    rs.diagnostics_radial = r.diagnostics_radial
-    rs.diagnostics_hardware = r.diagnostics_hardware
+    if hasattr(r,'diagnostics_radial'):
+	    rs.diagnostics_radial = r.diagnostics_radial
+    if hasattr(r,'diagnostics_hardware'):
+	    rs.diagnostics_hardware = r.diagnostics_hardware
     # the range information table changes in the processing from radial metric to radial short
     # but I have simply copied over the metric version for now
-    rs.range_information = r.range_information
+    if hasattr(r,'range_information'):
+	    rs.range_information = r.range_information
 
+    # remove table in rs that is not in r
+    r_tts = [r._tables[key]['TableType'].split(' ')[0] for key in r._tables.keys()]
+    rs_tts = [rs._tables[key]['TableType'].split(' ')[0] for key in rs._tables.keys()]
+    rs_keys= [key for key in rs._tables.keys()]
+    to_be_removed = [tt for tt in rs_tts if tt not in r_tts]
+
+    for tt in to_be_removed:
+        idx = rs_tts.index(tt)
+        rs._tables.pop(rs_keys[idx])
+    
     for key in rs._tables.keys():
         table = rs._tables[key]
         if 'LLUV' in table['TableType']:
@@ -403,8 +416,14 @@ def add_diagnostic_tables(r, shortpath):
 
     firstshortfn = os.path.join(shortpath, filelist[0])
     rs = read_lluv_file(firstshortfn)
-    rdtdata = rs.diagnostics_radial
-    hdtdata = rs.diagnostics_hardware
+    if hasattr(rs,'diagnostics_radial'):
+        rdtdata = rs.diagnostics_radial
+    else:
+        rdtdata = ''
+    if hasattr(rs,'diagnostics_hardware'):
+        hdtdata = rs.diagnostics_hardware
+    else:
+    	hdtdata = ''
 
     for shortfile in filelist:
         shortfullfile = os.path.join(shortpath, shortfile)
@@ -421,8 +440,10 @@ def add_diagnostic_tables(r, shortpath):
                 hdtdata = pd.concat([hdtdata, hdt], ignore_index=True)
 
     # remove duplicates
-    hdtdata = hdtdata.drop_duplicates(subset=['TYRS', 'TMON', 'TDAY', 'THRS', 'TMIN', 'TSEC'])
-    rdtdata = rdtdata.drop_duplicates(subset=['TYRS', 'TMON', 'TDAY', 'THRS', 'TMIN', 'TSEC'])
+    if rdtdata != '':
+        rdtdata = rdtdata.drop_duplicates(subset=['TYRS', 'TMON', 'TDAY', 'THRS', 'TMIN', 'TSEC'])
+    if hdtdata != '':
+        hdtdata = hdtdata.drop_duplicates(subset=['TYRS', 'TMON', 'TDAY', 'THRS', 'TMIN', 'TSEC'])
 
     # adjust rdt for seconds from start
     # adjust hdt for minutes from start


### PR DESCRIPTION
In offline processing there is no rcvr table appended to end of RadialMetric data (but have rads and RINT), whereas in the on site processing that table is included (rcvr, rads, RINT).  There is a template (file_formats/radialshort_LLUV_RDL7.ruv) that has all three (rcvr, rads, RINT) used in generate_radialshort(). 

Edited generate_radialshort() to handle if input RM diagnostic tables differ from the template tables types.  
Also edited add_diagnostic_tables() to handle when there is no rcvr table type.

This should resolve issue #11 now.